### PR TITLE
Switch from WTFPL to MIT License for standard open-source compliance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,21 @@
-        DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
-                    Version 2, December 2004 
+MIT License
 
- Copyright (C) 2025 stanfrbd 
+Copyright (c) 2025 stanfrbd
 
- Everyone is permitted to copy and distribute verbatim or modified 
- copies of this license document, and changing it is allowed as long 
- as the name is changed. 
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions:
 
-            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION 
+The above copyright notice and this permission notice shall be included 
+in all copies or substantial portions of the Software.
 
-  0. You just DO WHAT THE FUCK YOU WANT TO.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Ce commit modifie le fichier `LICENSE` au format MIT à la racine du projet, remplaçant la licence WTFPL.  
- Le texte complet de la licence MIT est désormais disponible dans `LICENSE`.  
- Permet de bénéficier d’une reconnaissance légale plus solide, tout en conservant une grande permissivité d’usage.  

**Changements :**  
- modificationdu fichier `LICENSE` (MIT).  
- Retrait des références à la licence WTFPL (si nécessaires).  

**Validation :**  
- [x] Vérifier que le nouveau fichier `LICENSE` est correct.  
- [x] Mettre à jour le `README.md` si besoin.  
- [x] Confirmer la compatibilité avec la politique open source du projet.  
