### PR TITLE
Advanced config - Ability to avoid secrets.json if ENV variables are provided - useful for Container deployment #34

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -1,9 +1,8 @@
 name: Build and Publish Docker image on GitHub Container Registry
-
 on:
   push:
     branches:
-      - advanced-config
+      - main
 
 jobs:
   build:

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -19,8 +19,6 @@ jobs:
         run: echo ${{ secrets.DEPLOYMENT_TOKEN }} | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
       - name: Build Docker image
-        env:
-          GUI_ENABLED_ENGINES: "reverse_dns,rdap,ipquery,abuseipdb,virustotal,spur,google_safe_browsing,shodan,phishtank,threatfox,urlscan,google,github,opencti,abusix,hudsonrock"
         run: docker build -t ghcr.io/${{ github.repository_owner }}/cyberbro:latest .
 
       - name: Push Docker image

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -22,14 +22,7 @@ jobs:
       - name: Build Docker image
         env:
           GUI_ENABLED_ENGINES: "reverse_dns,rdap,ipquery,abuseipdb,virustotal,spur,google_safe_browsing,shodan,phishtank,threatfox,urlscan,google,github,opencti,abusix,hudsonrock"
-        run: docker build -t cyberbro .
+        run: docker build -t ghcr.io/${{ github.repository_owner }}/cyberbro:latest
 
       - name: Push Docker image
-        run: docker push ghcr.io/${{ github.repository_owner }}/cyberbro
-
-      - name: Deploy Docker container
-        env:
-          GUI_ENABLED_ENGINES: "reverse_dns,rdap,ipquery,abuseipdb,virustotal,spur,google_safe_browsing,shodan,phishtank,threatfox,urlscan,google,github,opencti,abusix,hudsonrock"
-        run: docker run -d --name my-container \
-          -e GUI_ENABLED_ENGINES \
-          ghcr.io/${{ github.repository_owner }}/cyberbro
+        run: docker push ghcr.io/${{ github.repository_owner }}/cyberbro:latest

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build Docker image
         env:
           GUI_ENABLED_ENGINES: "reverse_dns,rdap,ipquery,abuseipdb,virustotal,spur,google_safe_browsing,shodan,phishtank,threatfox,urlscan,google,github,opencti,abusix,hudsonrock"
-        run: docker build -t ghcr.io/${{ github.repository_owner }}/cyberbro:latest
+        run: docker build -t ghcr.io/${{ github.repository_owner }}/cyberbro:latest .
 
       - name: Push Docker image
         run: docker push ghcr.io/${{ github.repository_owner }}/cyberbro:latest

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -1,0 +1,35 @@
+name: Build and Publish Docker image on GitHub Container Registry
+
+on:
+  push:
+    branches:
+      - advanced-config
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to GitHub Container Registry
+        run: echo ${{ secrets.DEPLOYMENT_TOKEN }} | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+
+      - name: Build Docker image
+        env:
+          GUI_ENABLED_ENGINES: "reverse_dns,rdap,ipquery,abuseipdb,virustotal,spur,google_safe_browsing,shodan,phishtank,threatfox,urlscan,google,github,opencti,abusix,hudsonrock"
+        run: docker build -t cyberbro .
+
+      - name: Push Docker image
+        run: docker push ghcr.io/${{ github.repository_owner }}/cyberbro
+
+      - name: Deploy Docker container
+        env:
+          GUI_ENABLED_ENGINES: "reverse_dns,rdap,ipquery,abuseipdb,virustotal,spur,google_safe_browsing,shodan,phishtank,threatfox,urlscan,google,github,opencti,abusix,hudsonrock"
+        run: docker run -d --name my-container \
+          -e GUI_ENABLED_ENGINES \
+          ghcr.io/${{ github.repository_owner }}/cyberbro

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from flask import Flask, request, render_template, jsonify, send_from_directory
 from flask_cors import CORS
 
 import ioc_fanger
+from utils.config import get_config, BASE_DIR, SECRETS_FILE
 from utils.utils import extract_observables
 from utils.export import prepare_data_for_export, export_to_csv, export_to_excel
 from models.analysis_result import AnalysisResult, db
@@ -18,30 +19,22 @@ app = Flask(__name__)
 # Enable CORS, very permisive. If you want to restrict it, you can use the origins parameter (can break the GUI)
 CORS(app)
 
-# Configure database
-BASE_DIR = os.path.abspath(os.path.dirname(__file__))
-
 # Ensure the data directory exists
 DATA_DIR = os.path.join(BASE_DIR, 'data')
 if not os.path.exists(DATA_DIR):
     os.makedirs(DATA_DIR)
 
-# Load secrets from a file
-SECRETS_FILE = os.path.join(BASE_DIR, 'secrets.json')
-if os.path.exists(SECRETS_FILE):
-    with open(SECRETS_FILE, 'r') as f:
-        secrets = json.load(f)
-else:
-    secrets = {}
+# Read the secrets from the secrets.json file
+secrets = get_config()
 
-# Define API_PREFIX if the variable api_prefix is set in secrets.json else it must be "api"
+# Define API_PREFIX
 API_PREFIX = secrets.get("api_prefix", "api")
 
-# Enable the config page - not intended for public use since authentication is not implemented - checks if the variable config_page_enabled is set in secrets.json
-app.config['CONFIG_PAGE_ENABLED'] = secrets.get('config_page_enabled', False)
+# Enable the config page - not intended for public use since authentication is not implemented
+app.config['CONFIG_PAGE_ENABLED'] = secrets.get("config_page_enabled", False)
 
-# Define gui_enabled_engines list if the variable of type list gui_enabled_engines is set in secrets.json
-GUI_ENABLED_ENGINES = secrets.get('gui_enabled_engines', [])
+# Define GUI_ENABLED_ENGINES
+GUI_ENABLED_ENGINES = secrets.get("gui_enabled_engines", [])
 
 # Update the database URI to use the data directory
 app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(DATA_DIR, 'results.db')}"
@@ -152,19 +145,31 @@ def update_config():
     if not app.config.get('CONFIG_PAGE_ENABLED', False):
         return jsonify({'message': 'Configuration update is disabled.'}), 403
     try:
-        secrets["proxy_url"] = request.form.get("proxy_url")
-        secrets["ipinfo"] = request.form.get("ipinfo")
-        secrets["mde_tenant_id"] = request.form.get("mde_tenant_id")
-        secrets["mde_client_id"] = request.form.get("mde_client_id")
-        secrets["mde_client_secret"] = request.form.get("mde_client_secret")
-        secrets["virustotal"] = request.form.get("virustotal")
-        secrets["google_safe_browsing"] = request.form.get("google_safe_browsing")
-        secrets["shodan"] = request.form.get("shodan")
+        secrets["proxy_url"] = request.form.get("proxy_url", secrets.get("proxy_url", ""))
+        secrets["virustotal"] = request.form.get("virustotal", secrets.get("virustotal", ""))
+        secrets["abuseipdb"] = request.form.get("abuseipdb", secrets.get("abuseipdb", ""))
+        secrets["ipinfo"] = request.form.get("ipinfo", secrets.get("ipinfo", ""))
+        secrets["google_safe_browsing"] = request.form.get("google_safe_browsing", secrets.get("google_safe_browsing", ""))
+        secrets["mde_tenant_id"] = request.form.get("mde_tenant_id", secrets.get("mde_tenant_id", ""))
+        secrets["mde_client_id"] = request.form.get("mde_client_id", secrets.get("mde_client_id", ""))
+        secrets["mde_client_secret"] = request.form.get("mde_client_secret", secrets.get("mde_client_secret", ""))
+        secrets["shodan"] = request.form.get("shodan", secrets.get("shodan", ""))
+        secrets["opencti_api_key"] = request.form.get("opencti_api_key", secrets.get("opencti_api_key", ""))
+        secrets["opencti_url"] = request.form.get("opencti_url", secrets.get("opencti_url", ""))
+        
+        # Apply the GUI_ENABLED_ENGINES configuration directly to the GUI to avoid restarting the app
+        global GUI_ENABLED_ENGINES
+        GUI_ENABLED_ENGINES = request.form.get("gui_enabled_engines", "")
+        secrets["gui_enabled_engines"] = [engine.strip() for engine in GUI_ENABLED_ENGINES.split(",")] if GUI_ENABLED_ENGINES else []
+        GUI_ENABLED_ENGINES = secrets["gui_enabled_engines"]
+        
+        # Save the secrets to the secrets.json file
         with open(SECRETS_FILE, 'w') as f:
             json.dump(secrets, f, indent=4)
+        
         message = "Configuration updated successfully."
     except Exception as e:
-        message = "An error occurred while updating the configuration."
+        message = f"An error occurred while updating the configuration. {e}"
     return jsonify({'message': message})
 
 @app.route(f'/{API_PREFIX}/results/<analysis_id>', methods=['GET'])

--- a/app.py
+++ b/app.py
@@ -160,7 +160,7 @@ def update_config():
         # Apply the GUI_ENABLED_ENGINES configuration directly to the GUI to avoid restarting the app
         global GUI_ENABLED_ENGINES
         GUI_ENABLED_ENGINES = request.form.get("gui_enabled_engines", "")
-        secrets["gui_enabled_engines"] = [engine.strip() for engine in GUI_ENABLED_ENGINES.split(",")] if GUI_ENABLED_ENGINES else []
+        secrets["gui_enabled_engines"] = [engine.strip().lower() for engine in GUI_ENABLED_ENGINES.split(",")] if GUI_ENABLED_ENGINES else []
         GUI_ENABLED_ENGINES = secrets["gui_enabled_engines"]
         
         # Save the secrets to the secrets.json file

--- a/prod/advanced_config.py
+++ b/prod/advanced_config.py
@@ -23,6 +23,7 @@ supervisor_conf_edited = False
 # Update the supervisord.conf with the new parameters if they exist
 workers_count = secrets.get('supervisord_workers_count') or os.getenv('SUPERVISORD_WORKERS_COUNT')
 threads_count = secrets.get('supervisord_threads_count') or os.getenv('SUPERVISORD_THREADS_COUNT')
+timeout = secrets.get('supervisord_timeout') or os.getenv('SUPERVISORD_TIMEOUT')
 
 if workers_count:
     config['program:cyberbro']['command'] = config['program:cyberbro']['command'].replace(
@@ -35,6 +36,13 @@ if threads_count:
     config['program:cyberbro']['command'] = config['program:cyberbro']['command'].replace(
         '-t ' + config['program:cyberbro']['command'].split('-t ')[1].split()[0],
         f"-t {threads_count}"
+    )
+    supervisor_conf_edited = True
+
+if timeout:
+    config['program:cyberbro']['command'] = config['program:cyberbro']['command'].replace(
+        '--timeout ' + config['program:cyberbro']['command'].split('--timeout ')[1].split()[0],
+        f"--timeout {timeout}"
     )
     supervisor_conf_edited = True
 

--- a/prod/advanced_config.py
+++ b/prod/advanced_config.py
@@ -8,9 +8,11 @@ secrets_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'secrets
 # Path to the supervisord.conf file
 supervisord_conf_file = os.path.join(os.path.dirname(__file__), 'supervisord.conf')
 
-# Read the secrets file
-with open(secrets_file, 'r') as f:
-    secrets = json.load(f)
+# Read the secrets file if it exists
+secrets = {}
+if os.path.exists(secrets_file):
+    with open(secrets_file, 'r') as f:
+        secrets = json.load(f)
 
 # Read the existing supervisord.conf
 config = configparser.ConfigParser()

--- a/prod/advanced_config.py
+++ b/prod/advanced_config.py
@@ -19,17 +19,20 @@ config.read(supervisord_conf_file)
 supervisor_conf_edited = False
 
 # Update the supervisord.conf with the new parameters if they exist
-if 'supervisord_workers_count' in secrets:
+workers_count = secrets.get('supervisord_workers_count') or os.getenv('SUPERVISORD_WORKERS_COUNT')
+threads_count = secrets.get('supervisord_threads_count') or os.getenv('SUPERVISORD_THREADS_COUNT')
+
+if workers_count:
     config['program:cyberbro']['command'] = config['program:cyberbro']['command'].replace(
         '-w ' + config['program:cyberbro']['command'].split('-w ')[1].split()[0],
-        f"-w {secrets['supervisord_workers_count']}"
+        f"-w {workers_count}"
     )
     supervisor_conf_edited = True
 
-if 'supervisord_threads_count' in secrets:
+if threads_count:
     config['program:cyberbro']['command'] = config['program:cyberbro']['command'].replace(
         '-t ' + config['program:cyberbro']['command'].split('-t ')[1].split()[0],
-        f"-t {secrets['supervisord_threads_count']}"
+        f"-t {threads_count}"
     )
     supervisor_conf_edited = True
 

--- a/prod/supervisord.conf
+++ b/prod/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:cyberbro]
-command=/usr/local/bin/gunicorn -w 4 -t 4 -b 0.0.0.0:5000 app:app
+command=/usr/local/bin/gunicorn -w 4 -t 4 -b 0.0.0.0:5000 app:app -t 120
 directory=/app
 user=root
 autostart=true

--- a/templates/config.html
+++ b/templates/config.html
@@ -374,7 +374,7 @@
                     {% endfor %}
                 </tbody>
             </table>
-            <button type="submit" class="btn save">Save</button>
+            <button type="submit" class="btn save" style="margin-bottom: 20px;">Save</button>
         </form>
 
         <div id="toast" class="toast"></div>

--- a/templates/config.html
+++ b/templates/config.html
@@ -176,6 +176,15 @@
             background-color: #e9ecef;
         }
 
+        .enabled_engines_value {
+            width: 100%;
+            border: 1px solid var(--border-color);
+            border-radius: var(--border-radius);
+            padding: 3px;
+            font-family: consolas, monospace;
+            background-color: #e9ecef;
+        }
+
         .footer {
             position: fixed;
             bottom: 0;
@@ -315,7 +324,10 @@
                 </thead>
                 <tbody>
                     {% for key, value in secrets.items() %}
+
+                    
                     <tr>
+                        {% if key not in ["gui_enabled_engines", "api_prefix", "config_page_enabled"] %}
                         <td style="width: 15%;">
                             <label class="secrets_key" for="secret_{{ key }}">{{ key }}</label>
                         </td>
@@ -325,15 +337,39 @@
                         </td>
                         <td style="width: 15%">
                             <button type="button" id="edit_{{ key }}" onclick="editSecret('{{ key }}')">✏️</button>
-                            <button type="button" id="cancel_{{ key }}" onclick="cancelEdit('{{ key }}', '{{ value }}')"
+                            <button type="button" id="cancel_{{ key }}" onclick="cancelEdit('{{ key }}', '{{ value }}', 'password')"
                                 style="display:none;">
                                 ❌
                             </button>
-                            <button type="button" id="validate_{{ key }}" onclick="validateEdit('{{ key }}')"
+                            <button type="button" id="validate_{{ key }}" onclick="validateEdit('{{ key }}', 'password')"
                                 style="display:none;">
                                 ✅
                             </button>
                         </td>
+                        
+                        {% endif %}
+                        
+                        {% if key == 'gui_enabled_engines' %}
+                        <td style="width: 15%;">
+                            <label class="secrets_key" for="secret_{{ key }}">{{ key }} (separated by ",")</label>
+                        </td>
+                        <td style="width: 50%;">
+                            <input class="enabled_engines_value" type="text" id="secret_{{ key }}" name="{{ key }}"
+                                value="{{ value | join(',') }}" readonly>
+                        </td>
+                        <td style="width: 15%">
+                            <button type="button" id="edit_{{ key }}" onclick="editSecret('{{ key }}')">✏️</button>
+                            <button type="button" id="cancel_{{ key }}" onclick="cancelEdit('{{ key }}', '{{ value | join(',') }}', 'text')"
+                                style="display:none;">
+                                ❌
+                            </button>
+                            <button type="button" id="validate_{{ key }}" onclick="validateEdit('{{ key }}', 'text')"
+                                style="display:none;">
+                                ✅
+                            </button>
+                        </td>
+                        {% endif %}
+
                     </tr>
                     {% endfor %}
                 </tbody>
@@ -354,23 +390,23 @@
                 document.getElementById('edit_' + key).style.display = 'none';
             }
 
-            function cancelEdit(key, originalValue) {
+            function cancelEdit(key, originalValue, input_type) {
                 const input = document.getElementById('secret_' + key);
                 input.value = input.dataset.originalValue;
-                input.type = 'password';
+                input.type = input_type;
                 input.readOnly = true;
                 document.getElementById('cancel_' + key).style.display = 'none';
                 document.getElementById('validate_' + key).style.display = 'none';
                 document.getElementById('edit_' + key).style.display = 'inline';
             }
 
-            function validateEdit(key) {
+            function validateEdit(key, input_type) {
                 const input = document.getElementById('secret_' + key);
                 input.readOnly = true;
                 document.getElementById('cancel_' + key).style.display = 'none';
                 document.getElementById('validate_' + key).style.display = 'none';
                 document.getElementById('edit_' + key).style.display = 'inline';
-                input.type = 'password';
+                input.type = input_type;
             }
 
             document.getElementById('configForm').addEventListener('submit', function (event) {

--- a/templates/config.html
+++ b/templates/config.html
@@ -351,7 +351,7 @@
                         
                         {% if key == 'gui_enabled_engines' %}
                         <td style="width: 15%;">
-                            <label class="secrets_key" for="secret_{{ key }}">{{ key }} (separated by ",")</label>
+                            <label class="secrets_key" for="secret_{{ key }}">{{ key }} (separated by ",") - when empty, all engines are enabled.</label>
                         </td>
                         <td style="width: 50%;">
                             <input class="enabled_engines_value" type="text" id="secret_{{ key }}" name="{{ key }}"

--- a/templates/config.html
+++ b/templates/config.html
@@ -76,7 +76,7 @@
         }
 
         .btn.save {
-            padding-bottom: 20px;
+            bottom: 20px;
         }
 
         .btn:hover {

--- a/templates/config.html
+++ b/templates/config.html
@@ -75,10 +75,6 @@
             transition: background-color 0.3s;
         }
 
-        .btn.save {
-            bottom: 20px;
-        }
-
         .btn:hover {
             background-color: var(--primary-hover-color);
         }
@@ -471,7 +467,7 @@
         applyDarkMode();
     </script>
 </body>
-<footer class="footer">
+<footer class="footer" style="margin-top: 20px;">
     <nav>
         <ul>
             <li><a href="/">Home</a></li>

--- a/templates/config.html
+++ b/templates/config.html
@@ -75,6 +75,10 @@
             transition: background-color 0.3s;
         }
 
+        .btn.save {
+            padding-bottom: 20px;
+        }
+
         .btn:hover {
             background-color: var(--primary-hover-color);
         }

--- a/utils/config.py
+++ b/utils/config.py
@@ -67,6 +67,7 @@ try:
         logging.info("Secrets file was automatically generated.")
 
 except Exception as e:
+    print("Error while loading secrets:", e)
     logging.error("Error while loading secrets: %s", e)
     exit(1)
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,9 +1,11 @@
 import os
 import json
 
+import logging
+
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
-print("BASE_DIR: ", BASE_DIR)
+logging.debug("BASE_DIR: %s", BASE_DIR)
 
 # Define the path to the secrets file
 SECRETS_FILE = os.path.join(BASE_DIR, 'secrets.json')
@@ -27,31 +29,36 @@ secrets = {
 }
 
 # Load secrets from secrets.json if it exists
-if os.path.exists(SECRETS_FILE):
-    with open(SECRETS_FILE, 'r') as f:
-        secrets.update(json.load(f))
-else:
-    print("Secrets file not found. Trying to read environment variables...")
+try:
+    if os.path.exists(SECRETS_FILE):
+        with open(SECRETS_FILE, 'r') as f:
+            secrets.update(json.load(f))
+    else:
+        print("Secrets file not found. Trying to read environment variables...")
 
-    # Load secrets from environment variables
-    for key in secrets.keys():
-        env_value = os.getenv(key.upper())
-        if env_value:
-            if key == "gui_enabled_engines":
-                # Split the comma-separated list of engines into a list
-                secrets[key] = env_value.split(",")
-            else:
-                secrets[key] = env_value
+        # Load secrets from environment variables
+        for key in secrets.keys():
+            env_value = os.getenv(key.upper())
+            if env_value:
+                if key == "gui_enabled_engines":
+                    # Split the comma-separated list of engines into a list
+                    secrets[key] = env_value.split(",")
+                else:
+                    secrets[key] = env_value
 
-    # Check if mandatory variable is set
-    if not secrets["proxy_url"]:
-        print("Error: No secrets.json file found and no environment variables set. Terminating the app.")
-        exit(1)
+        # Check if mandatory variable is set
+        if not secrets["proxy_url"]:
+            logging.error("Error: No secrets.json file found and no environment variables set. Terminating the app.")
+            exit(1)
 
-    # Dump the variables and create the secrets.json file if at least proxy_url is set
-    with open(SECRETS_FILE, 'w') as f:
-        json.dump(secrets, f, indent=4)
-    print("Secrets file was automatically generated.")
+        # Dump the variables and create the secrets.json file if at least proxy_url is set
+        with open(SECRETS_FILE, 'w') as f:
+            json.dump(secrets, f, indent=4)
+        logging.info("Secrets file was automatically generated.")
+
+except Exception as e:
+    logging.error("Error while loading secrets: %s", e)
+    exit(1)
 
 def get_config():
     return secrets

--- a/utils/config.py
+++ b/utils/config.py
@@ -45,7 +45,7 @@ try:
                 env_configured = True
                 if key == "gui_enabled_engines":
                     # Split the comma-separated list of engines into a list
-                    secrets[key] = env_value.split(",")
+                    secrets[key] = [engine.strip().lower() for engine in env_value.split(",")]
                 elif key == "config_page_enabled":
                     secrets[key] = env_value.lower() in ["true", "1", "yes"]
                 else:

--- a/utils/config.py
+++ b/utils/config.py
@@ -35,24 +35,33 @@ try:
             secrets.update(json.load(f))
     else:
         print("Secrets file not found. Trying to read environment variables...")
+        logging.info("Secrets file not found. Trying to read environment variables...")
 
         # Load secrets from environment variables
+        env_configured = False
         for key in secrets.keys():
             env_value = os.getenv(key.upper())
             if env_value:
-                if key == "gui_enabled_engines":
-                    # Split the comma-separated list of engines into a list
-                    secrets[key] = env_value.split(",")
-                else:
-                    secrets[key] = env_value
+                env_configured = True
+            if key == "gui_enabled_engines":
+                # Split the comma-separated list of engines into a list
+                secrets[key] = env_value.split(",")
+            else:
+                secrets[key] = env_value
 
-        # Check if mandatory variable is set
+        # Check if proxy variable is set
         if not secrets["proxy_url"]:
+            print("No proxy URL was set. Using no proxy.")
             logging.info("No proxy URL was set. Using no proxy.")
+
+        if not env_configured:
+            print("No environment variables were configured. You can configure secrets later in secrets.json.")
+            logging.info("No environment variables were configured. You can configure secrets later in secrets.json.")
 
         # Dump the variables and create the secrets.json file if at least proxy_url is set
         with open(SECRETS_FILE, 'w') as f:
             json.dump(secrets, f, indent=4)
+        print("Secrets file was automatically generated.")
         logging.info("Secrets file was automatically generated.")
 
 except Exception as e:

--- a/utils/config.py
+++ b/utils/config.py
@@ -43,11 +43,11 @@ try:
             env_value = os.getenv(key.upper())
             if env_value:
                 env_configured = True
-            if key == "gui_enabled_engines":
-                # Split the comma-separated list of engines into a list
-                secrets[key] = env_value.split(",")
-            else:
-                secrets[key] = env_value
+                if key == "gui_enabled_engines":
+                    # Split the comma-separated list of engines into a list
+                    secrets[key] = env_value.split(",")
+                else:
+                    secrets[key] = env_value
 
         # Check if proxy variable is set
         if not secrets["proxy_url"]:

--- a/utils/config.py
+++ b/utils/config.py
@@ -46,6 +46,8 @@ try:
                 if key == "gui_enabled_engines":
                     # Split the comma-separated list of engines into a list
                     secrets[key] = env_value.split(",")
+                elif key == "config_page_enabled":
+                    secrets[key] = env_value.lower() in ["true", "1", "yes"]
                 else:
                     secrets[key] = env_value
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -48,8 +48,7 @@ try:
 
         # Check if mandatory variable is set
         if not secrets["proxy_url"]:
-            logging.error("Error: No secrets.json file found and no environment variables set. Terminating the app.")
-            exit(1)
+            logging.info("No proxy URL was set. Using no proxy.")
 
         # Dump the variables and create the secrets.json file if at least proxy_url is set
         with open(SECRETS_FILE, 'w') as f:

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,0 +1,57 @@
+import os
+import json
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+print("BASE_DIR: ", BASE_DIR)
+
+# Define the path to the secrets file
+SECRETS_FILE = os.path.join(BASE_DIR, 'secrets.json')
+
+# Initialize secrets dictionary with default values
+secrets = {
+    "proxy_url": "",
+    "virustotal": "",
+    "abuseipdb": "",
+    "ipinfo": "",
+    "google_safe_browsing": "",
+    "mde_tenant_id": "",
+    "mde_client_id": "",
+    "mde_client_secret": "",
+    "shodan": "",
+    "opencti_api_key": "",
+    "opencti_url": "", 
+    "api_prefix": "api",
+    "config_page_enabled": False,
+    "gui_enabled_engines": []
+}
+
+# Load secrets from secrets.json if it exists
+if os.path.exists(SECRETS_FILE):
+    with open(SECRETS_FILE, 'r') as f:
+        secrets.update(json.load(f))
+else:
+    print("Secrets file not found. Trying to read environment variables...")
+
+    # Load secrets from environment variables
+    for key in secrets.keys():
+        env_value = os.getenv(key.upper())
+        if env_value:
+            if key == "gui_enabled_engines":
+                # Split the comma-separated list of engines into a list
+                secrets[key] = env_value.split(",")
+            else:
+                secrets[key] = env_value
+
+    # Check if mandatory variable is set
+    if not secrets["proxy_url"]:
+        print("Error: No secrets.json file found and no environment variables set. Terminating the app.")
+        exit(1)
+
+    # Dump the variables and create the secrets.json file if at least proxy_url is set
+    with open(SECRETS_FILE, 'w') as f:
+        json.dump(secrets, f, indent=4)
+    print("Secrets file was automatically generated.")
+
+def get_config():
+    return secrets

--- a/utils/database.py
+++ b/utils/database.py
@@ -1,10 +1,8 @@
 from models.analysis_result import AnalysisResult, db
 
 def save_analysis_result(analysis_result):
-    """Save the analysis result to the database."""
     db.session.add(analysis_result)
     db.session.commit()
 
 def get_analysis_result(analysis_id):
-    """Get the analysis result from the database."""
     return db.session.query(AnalysisResult).filter_by(id=analysis_id).first()

--- a/utils/stats.py
+++ b/utils/stats.py
@@ -1,7 +1,6 @@
 from models.analysis_result import AnalysisResult, db
 
 def get_analysis_stats():
-    """Get analysis statistics from the database."""
     analyses = db.session.query(AnalysisResult).all()
     num_analyses = len(analyses)
     


### PR DESCRIPTION
# Advanced options for deployment (See the wiki) for #34 

## All variables from `secrets.json` can be converted to **environment variables** (uppercase):

> [!NOTE]
> You can add these environment variables in a custom `docker-compose.yml`. If you don't specify proxy, no proxy will be used.

```bash
export PROXY_URL="http://127.0.0.1:9000"
export VIRUSTOTAL="api_key_here"
export ABUSEIPDB="api_key_here"
export IPINFO="api_key_here"
export GOOGLE_SAFE_BROWSING="api_key_here"
export MDE_TENANT_ID="api_key_here"
export MDE_CLIENT_ID="api_key_here"
export MDE_CLIENT_SECRET="api_key_here"
export SHODAN="api_key_here"
export OPENCTI_API_KEY="api_key_here"
export OPENCTI_URL="https://demo.opencti.io"
```

## Supervisord options (for docker only)

This options will be applied only if the script `prod/advanced_config.py` is run (automatic in docker)

**In `secrets.json`:**

* Adding `"supervisord_workers_count": 1` in `secrets.json` will set `-w 1` in `supervisord.conf`
* Adding `"supervisord_threads_count": 1` in `secrets.json` will set `-t 1` in `supervisord.conf`
* Adding `"supervisord_timeout": 200` in `secrets.json` will set `--timeout 200` in `supervisord.conf`

**Or using environment variables:**

```bash
export SUPERVISORD_WORKERS_COUNT=1
export SUPERVISORD_THREADS_COUNT=1
export SUPERVISORD_TIMEOUT=200
```

> [!NOTE]
> These variables are optional, so if they don't exist in `secrets.json`, the original config (in `prod/supervisord.conf`) will be applied by default.

## API prefix in `app.py` and `index.html` options

**In `secrets.json`:**

* Adding `"api_prefix": "my_api"` in `secrets.json` will set all the original prefix `/api/` endpoints to be renamed by prefix `/my_api/` endpoints in the files `app.py` and `index.html`

**Or using environment variables:**

```bash
export API_PREFIX="my_api"
```

> [!NOTE]
> This variable is optional, so if it doesn't exist in `secrets.json`, the API will be accessible at `/api/` by default.

## Selected engines in the GUI (`index.html` only)

**In `secrets.json`:**

* Adding `"gui_enabled_engines": ["reverse_dns", "rdap"]` in `secrets.json` will restrict usage of these two engines in the GUI.

**Or using environment variables:**

```bash
export GUI_ENABLED_ENGINES="reverse_dns,rdap"
```

> [!NOTE]
> This variable is optional, so if it doesn't exist in `secrets.json`, all engines will be displayed in the GUI.

> [!TIP]
> Example: for the demo instance of cyberbro, only these engines are used: 
> `"gui_enabled_engines": ["reverse_dns", "rdap", "ipquery", "abuseipdb", "virustotal", "spur", "google_safe_browsing", "shodan", "phishtank", "threatfox", "urlscan", "google", "github", "opencti", "abusix", "hudsonrock"]` \
> With environment variable: `GUI_ENABLED_ENGINES="reverse_dns,rdap,ipquery,abuseipdb,virustotal,spur,google_safe_browsing,shodan,phishtank,threatfox,urlscan,google,github,opencti,abusix,hudsonrock"`

## Config page in the GUI (`config.html`) http://cyberbro.local:5000/config

> [!CAUTION]
> This is unsecure so it is disabled by default.

You can add it using the following:

**In `secrets.json`:**

Adding `"config_page_enabled": true` in `secrets.json` will enable the config page in the GUI at http://cyberbro.local:5000/config

**Or using environment variables:**

```bash
export CONFIG_PAGE_ENABLED="true"
```

> [!NOTE]
> This variable is optional, so if it doesn't exist in `secrets.json`, it will be disabled by default.