### PR TITLE
Advanced config - Add caching for the API and for the GUI

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,11 +36,13 @@ secrets = get_config()
 # Cache configuration
 app.config['CACHE_TYPE'] = 'SimpleCache'
 app.config['CACHE_DEFAULT_TIMEOUT'] = secrets.get("api_cache_timeout", 86400)  # Default to 1 day
+logger.debug(f"CACHE_DEFAULT_TIMEOUT: {app.config['CACHE_DEFAULT_TIMEOUT']}")
+
 cache = Cache(app)
 
 # Retrieve from secrets or default to 1MB - MAX_FORM_MEMORY_SIZE is the maximum size of the form data in bytes
 app.config['MAX_FORM_MEMORY_SIZE'] = secrets.get("max_form_memory_size", 1 * 1024 * 1024)
-print(f"MAX_FORM_MEMORY_SIZE: {app.config['MAX_FORM_MEMORY_SIZE']}")
+logger.debug(f"MAX_FORM_MEMORY_SIZE: {app.config['MAX_FORM_MEMORY_SIZE']}")
 
 # Define API_PREFIX
 API_PREFIX = secrets.get("api_prefix", "api")

--- a/app.py
+++ b/app.py
@@ -64,7 +64,7 @@ app.config['SQLALCHEMY_POOL_SIZE'] = 10
 app.config['SQLALCHEMY_MAX_OVERFLOW'] = 20
 
 # Set version 
-app.config['VERSION'] = "v0.6.3"
+app.config['VERSION'] = "v0.6.4"
 
 # Initialize the database
 db.init_app(app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 requests
 flask
 flask-cors
+flask-caching
 pandas
 jwt
 openpyxl

--- a/templates/413.html
+++ b/templates/413.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>413 Payload Too Large</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f2f2f2;
+            color: #333;
+            text-align: center;
+            padding: 50px;
+        }
+
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+        }
+
+        h1 {
+            font-size: 48px;
+            margin-bottom: 20px;
+        }
+
+        p {
+            font-size: 18px;
+            margin-bottom: 30px;
+        }
+
+        a {
+            color: #007BFF;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .image {
+            margin: 20px 0;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <h1>413</h1>
+        <p>Payload Too Large</p>
+        <p>Whoa there! Looks like you tried to upload something a bit too hefty. Maybe try to paste less data?</p>
+        <p>If this is from the demo, remember: this limit is here to avoid users breaking the API quotas. Sharing is caring!</p>
+        <div class="image">
+            <img src="https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg" alt="Fat Cat" width="200">
+        </div>
+        <p><a href="/">Go back to Home</a></p>
+        <a href="https://github.com/stanfrbd/cyberbro" target="_blank" class="github-logo">
+            <img src="https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg" alt="GitHub Logo"
+                width="40" height="40" class="github-logo">
+        </a>
+    </div>
+</body>
+
+</html>

--- a/utils/config.py
+++ b/utils/config.py
@@ -27,13 +27,15 @@ secrets = {
     "opencti_url": "",
     "crowdstrike_client_id": "",
     "crowdstrike_client_secret": "",
-    "crowdstrike_falcon_base_url": "https://falcon.crowdstrike.com",
+    "crowdstrike_falcon_base_url": "https://falcon.crowdstrike.com", # Default URL
     "webscout": "",
-    "max_form_memory_size": 1048576,
+    "max_form_memory_size": 1048576, # 1 MB
     "api_prefix": "api",
     "config_page_enabled": False,
     "gui_enabled_engines": [],
-    "ssl_verify": True
+    "ssl_verify": True, # Default to be secure
+    "api_cache_timeout": 86400,  # Default to 1 day
+    "gui_cache_timeout": 1800   # Default to 30 minutes
 }
 
 secrets_file_exists = False


### PR DESCRIPTION
This is to address #52 
- Add default cache of 30 min for the GUI
- Add default cache of 1 day for the API
- configurable using the `gui_cache_timeout` and `api_cache_timeout` variables in `secrets.json` or
- configurable using the `GUI_CACHE_TIMEOUT` and `API_CACHE_TIMEOUT` environment variables
- To ignore cache for the API: add `"ignore_cache": true` in the query (data section)
- All timeouts are defined in **seconds**
- Other: add a funny 413 page 