### PR TITLE
Fix crt.sh table when querying multiple observables

### DIFF
--- a/engines/crtsh.py
+++ b/engines/crtsh.py
@@ -40,9 +40,9 @@ def query_crtsh(
             domain_part = observable.split("/")[2].split(":")[0]
             observable = domain_part
 
-        url = f"https://crt.sh/?q={observable}&output=json"
+        url = f"https://crt.sh/json?q={observable}"
 
-        response = requests.get(url, proxies=proxies, verify=ssl_verify, timeout=10)
+        response = requests.get(url, proxies=proxies, verify=ssl_verify, timeout=20)
         response.raise_for_status()
 
         results = response.json()
@@ -50,7 +50,7 @@ def query_crtsh(
         for entry in results:
             domains = set()
 
-            common_name	= entry.get("common_name", None)
+            common_name = entry.get("common_name", None)
             if common_name is not None and len(common_name) != 0:
                 domains.add(common_name)
 
@@ -59,7 +59,7 @@ def query_crtsh(
                 for el in name_value.split("\n"):
                     if len(el) > 0:
                         domains.add(str(el).strip())
-            
+
             for domain in domains:
                 domain_count[domain] = domain_count.get(domain, 0) + 1
 

--- a/engines/crtsh.py
+++ b/engines/crtsh.py
@@ -33,11 +33,6 @@ def query_crtsh(
               }
         None: If an error occurs.
     """
-    query_fields = {
-        "URL": "page.domain",
-        "FQDN": "page.domain"
-    }
-    query_field = query_fields.get(observable_type, "page.domain")
 
     try:
         # If observable is a URL, extract domain

--- a/templates/display_table.html
+++ b/templates/display_table.html
@@ -317,6 +317,11 @@
             {% if "misp" in analysis_results.selected_engines %}
             {% include "engine_layouts/misp_table.html" %}
             {% endif %}
+
+            {% if "crtsh" in analysis_results.selected_engines %}
+            {% include "engine_layouts/crtsh_table.html" %}
+            {% endif %}
+
         </tr>
         {% endfor %}
     </tbody>

--- a/templates/engine_layouts/crtsh_table.html
+++ b/templates/engine_layouts/crtsh_table.html
@@ -1,0 +1,23 @@
+<td>
+    {% if result.crtsh %}
+        <strong>Scan count:</strong> <a href="{{ result.crtsh.link }}" target="_blank">{{ result.crtsh.scan_count }}</a><br/>
+        {% if result.crtsh.scan_count == 0 %}
+            Not Found
+        {% else %}
+            <strong>
+            {% if result.type in ["FQDN", "URL"] %}
+                Top domains:
+            {% else %}
+                Top related domains:
+            {% endif %}
+            </strong>
+            <ul>
+            {% for domain in result.crtsh.top_domains %}
+                <li>{{ domain.domain }} ({{ domain.count }})</li>
+            {% endfor %}
+            </ul>
+        {% endif %}
+    {% else %}
+        Not applicable
+    {% endif %}
+</td>


### PR DESCRIPTION
Hi,

I tested out the newly added CRT.SH feature. The thing that didn't work was when querying multiple observables, then the resulting column for CRT was blank in the table.

So, I added the table file, `templates/engine_layouts/crtsh_table.html`.

I have also changed the timeout since in my experience crt.sh is quite slow, and the URL. There is a different path for JSON responses that seems to work out better, fewer timeouts. At least for me.

But this is obviously an opinion.

I have tested this commit, and it works for me.