### PR TITLE
fix: Adjust to get past Bandit tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -422,4 +422,4 @@ def graph(analysis_id):
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000, debug=False)
+    app.run(port=5000, debug=False)

--- a/utils/export.py
+++ b/utils/export.py
@@ -1,9 +1,12 @@
+import logging
 import threading
 import time
 from pathlib import Path
 
 import pandas as pd
 from flask import send_file
+
+logger = logging.getLogger(__name__)
 
 
 def prepare_row(result, selected_engines):
@@ -297,8 +300,8 @@ def export_to_excel(data, timestamp):
                 try:
                     if len(str(cell.value)) > max_length:
                         max_length = len(str(cell.value))
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.error("Error exporting to Excel, column %s, cell %s, '%s'", column, cell, e, exc_info=True)
             adjusted_width = max_length + 2
             worksheet.column_dimensions[column].width = adjusted_width
     response = send_file(excel_path, as_attachment=True)


### PR DESCRIPTION
Hi,

This is related to the issue #113.

I have adjusted `app.py` and `utils/export.py` so they now pass the Bandit tests.
- Issue: [B104:hardcoded_bind_all_interfaces] Possible binding to all interfaces.
- Issue: [B110:try_except_pass] Try, Except, Pass detected.

I have not done anything magic, just removing the `host="0.0.0.0"` from `app.py` stops Bandit from complaining while still make it work as before.

I have tested it for docker and also running it directly with gunicorn and python3 as described on the [Quick Start & Installation](https://docs.cyberbro.net/quick-start/Quick-start-%26-Installation/)  page.

In the `exports.py` I just added a log statement. I have encountered any errors exporting, so not sure how this will behave if there actually is an error. But it should just log the error.

The ports command in docker compose exposes the service on 0.0.0.0 by default, and when running gunicorn on the command line you explicitly state what the interface should be.

Running `python3 app.py` will put it in debug mode, and only listen on 127.0.0.1.

So, I think this is the simple solution to the problem on how to customize the interface and port.
If anyone wants a different interface/port they can adjust the docker compose file or the gunicorn command line.

But you have to verify it this is OK.

